### PR TITLE
Updates, API usage, crash avoidance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ minecraft {
 
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 
             mods {
                 examplemod {
@@ -39,6 +41,8 @@ minecraft {
 
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 
             mods {
                 examplemod {
@@ -52,6 +56,8 @@ minecraft {
 
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 
             args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
 
@@ -82,10 +88,11 @@ repositories {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.16.4-35.0.15'
+    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
 
     //Vampirism
-    compileOnly fg.deobf("de.teamlapen.vampirism:Vampirism:1.16.4-1.7.8")
+    compileOnly fg.deobf("de.teamlapen.vampirism:Vampirism:1.16.4-1.7.12:api")
+    runtimeOnly fg.deobf("de.teamlapen.vampirism:Vampirism:1.16.4-1.7.12")
 
     //Curios
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.16.5-4.0.5.0")

--- a/src/main/java/com/focamacho/vampiresneedumbrellas/handlers/VampirismHandler.java
+++ b/src/main/java/com/focamacho/vampiresneedumbrellas/handlers/VampirismHandler.java
@@ -3,25 +3,30 @@ package com.focamacho.vampiresneedumbrellas.handlers;
 import com.focamacho.vampiresneedumbrellas.config.ConfigHolder;
 import com.focamacho.vampiresneedumbrellas.potions.SunscreenEffectInstance;
 import com.focamacho.vampiresneedumbrellas.utils.Utils;
-import de.teamlapen.vampirism.core.ModEffects;
-import de.teamlapen.vampirism.player.vampire.VampirePlayer;
+import de.teamlapen.vampirism.api.VReference;
+import de.teamlapen.vampirism.api.VampirismAPI;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Effect;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.world.World;
+import net.minecraftforge.registries.ObjectHolder;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 import java.util.Optional;
 
 public class VampirismHandler {
 
+	@ObjectHolder("vampirism:sunscreen")
+	private static Effect vampirism_sunscreen;
+
 	public static void applyEffect(ItemStack stack, World world, Entity entityIn, boolean breakable) {
 		if (canApplyEffect(entityIn)) {
 			PlayerEntity player = (PlayerEntity) entityIn;
 			if ((ConfigHolder.umbrellaMainHand && player.getHeldItemMainhand().equals(stack)) || (ConfigHolder.umbrellaOffHand && player.getHeldItemOffhand().equals(stack))) {
-				player.addPotionEffect(new SunscreenEffectInstance());
-				if (breakable && VampirePlayer.get(player).isGettingSundamage(world)) {
+				player.addPotionEffect(new SunscreenEffectInstance(vampirism_sunscreen));
+				if (breakable && VReference.VAMPIRE_FACTION.getPlayerCapability(player).map(v->v.isGettingSundamage(world)).orElse(false)) {
 					stack.damageItem(1, player, consumer -> consumer.sendBreakAnimation(player.getActiveHand()));
 				}
 				return;
@@ -31,9 +36,9 @@ public class VampirismHandler {
 				Optional<ImmutableTriple<String, Integer, ItemStack>> opt = CuriosHandler.getUmbrellaEquiped(stack, player);
 				if(opt.isPresent()) {
 					ImmutableTriple<String, Integer, ItemStack> umbrella = opt.get();
-					player.addPotionEffect(new SunscreenEffectInstance());
+					player.addPotionEffect(new SunscreenEffectInstance(vampirism_sunscreen));
 
-					if (breakable && VampirePlayer.get(player).isGettingSundamage(world)) {
+					if (breakable && VReference.VAMPIRE_FACTION.getPlayerCapability(player).map(v->v.isGettingSundamage(world)).orElse(false)) {
 						String id = umbrella.getLeft();
 						Integer index = umbrella.getMiddle();
 
@@ -48,11 +53,11 @@ public class VampirismHandler {
 		if (canApplyEffect(entityIn)) {
 			PlayerEntity player = (PlayerEntity)entityIn;
 			if ((ConfigHolder.creativeUmbrellaConfigs && ((ConfigHolder.umbrellaMainHand && player.getHeldItemMainhand().equals(stack)) || (ConfigHolder.umbrellaOffHand && player.getHeldItemOffhand().equals(stack))))) {
-				player.addPotionEffect(new SunscreenEffectInstance());
+				player.addPotionEffect(new SunscreenEffectInstance(vampirism_sunscreen));
 			} else if ((player.getHeldItemMainhand().equals(stack) || player.getHeldItemOffhand().equals(stack) || (Utils.isCuriosLoaded && ConfigHolder.umbrellaBauble && CuriosHandler.getUmbrellaEquiped(stack, player).isPresent()))) {
-				player.addPotionEffect(new SunscreenEffectInstance());
+				player.addPotionEffect(new SunscreenEffectInstance(vampirism_sunscreen));
 			} else if(Utils.isCuriosLoaded && ConfigHolder.umbrellaBauble && CuriosHandler.getUmbrellaEquiped(stack, player).isPresent()) {
-				player.addPotionEffect(new SunscreenEffectInstance());
+				player.addPotionEffect(new SunscreenEffectInstance(vampirism_sunscreen));
 			}
 		}
 	}
@@ -60,7 +65,7 @@ public class VampirismHandler {
 	private static boolean canApplyEffect(Entity entity) {
 		if(!(entity instanceof PlayerEntity)) return false;
 		PlayerEntity player = (PlayerEntity) entity;
-		EffectInstance effectInstance = player.getActivePotionEffect(ModEffects.sunscreen);
+		EffectInstance effectInstance = player.getActivePotionEffect(vampirism_sunscreen);
 		return effectInstance == null || effectInstance.getDuration() <= 1;
 	}
 

--- a/src/main/java/com/focamacho/vampiresneedumbrellas/potions/SunscreenEffectInstance.java
+++ b/src/main/java/com/focamacho/vampiresneedumbrellas/potions/SunscreenEffectInstance.java
@@ -1,14 +1,14 @@
 package com.focamacho.vampiresneedumbrellas.potions;
 
-import de.teamlapen.vampirism.core.ModEffects;
+import net.minecraft.potion.Effect;
 import net.minecraft.potion.EffectInstance;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 public class SunscreenEffectInstance extends EffectInstance {
 
-    public SunscreenEffectInstance() {
-        super(ModEffects.sunscreen, 21, 5, false, false);
+    public SunscreenEffectInstance(Effect sunscreenEffect) {
+        super(sunscreenEffect, 21, 5, false, false);
     }
 
     @OnlyIn(Dist.CLIENT)


### PR DESCRIPTION
Hey,

this PR does several small things. If you want, you can also manually cherry pick changes.

## Use LazyOptional of capability
Use `VReference.VAMPIRE_FACTION.getPlayerCapability(player)` (or `VampirePlayer.getOpt(player)`) to get a LazyOptional of the capability instead of the capability itself.
When a player is dead the capability is invalid and `VampirePlayer#get` throws. This can also happen under certain other unknown circumstances. Therefore it is better to use the optional mapper.
Avoids e.g. https://paste.ee/p/B11V3

## Add mixin remap to run configurations
Without these the game won't run in dev environment when this mod uses different mappings than Vampirism

## Don't depend on the main mod, but only on the API
This avoid issues with Vampirism updates as I try to keep the API perfectly stable within MC versions.
Use ObjectHolders for the sunscreen effect to avoid hard dependency.

The full mod is still loaded during runtime

## Bump Vampirism (and Forge)
To 1.7.12